### PR TITLE
Fix silly e2e issue where config was interpreted as cjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 vite.config.*.timestamp*
 vitest.config.*.timestamp*
 test-output
+
+test-results

--- a/apps/nx-demo-e2e/playwright.config.ts
+++ b/apps/nx-demo-e2e/playwright.config.ts
@@ -10,7 +10,7 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:4300';
 
 /** See https://playwright.dev/docs/test-configuration. */
 export default defineConfig({
-	...nxE2EPreset(import.meta.filename, { testDir: './src' }),
+	...nxE2EPreset(__filename, { testDir: './src' }),
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		baseURL,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,4 @@
 {
-	"compileOnSave": false,
 	"compilerOptions": {
 		"baseUrl": ".",
 


### PR DESCRIPTION
using import.meta.filename caused something in playwright to treat the config as commonjs. Using __filename for now even though I don't understand how that works when this is type module